### PR TITLE
readme: mention that the SteamID64 should be decimal, not hex

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A simple save decryption, encryption and conversion utility for P5S PC.
 
 - Locate `SAVEDATA.BIN` under `%APPDATA%\SEGA\Steam\P5S\<account_id>\`
 
-- Get the **SteamID64** associated with the account under which the save was created
+- Get the decimal **SteamID64** associated with the account under which the save was created
 
   The last segment of **SteamID3** will also work (`[U:1:<last_segment>]`)
 


### PR DESCRIPTION
Hi,

Thanks a lot for this tool!

I struggled a bit with the steamID format: the program would exit and show me the help as if I didn't set the right CLI flags.

Took me a couple of minutes to notice that I used a hex SteamID64 from https://steamidfinder.com/ rather than the Decimal version.

While this error could be handled in code, I think that just adding this in the readme does the trick well enough.